### PR TITLE
Add confirmed family members and reverse DNS details to relay dialog

### DIFF
--- a/backend/src/main/kotlin/org/tormap/adapter/controller/RelayDetailsController.kt
+++ b/backend/src/main/kotlin/org/tormap/adapter/controller/RelayDetailsController.kt
@@ -2,21 +2,18 @@ package org.tormap.adapter.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.*
-import org.tormap.adapter.controller.exception.RelayNotFoundException
-import org.tormap.database.entity.RelayDetails
 import org.tormap.database.repository.RelayDetailsRepositoryImpl
+import org.tormap.service.RelayDetailsQueryService
 
 @RestController
 @RequestMapping("relay/details/")
 class RelayDetailsController(
     val relayDetailsRepositoryImpl: RelayDetailsRepositoryImpl,
+    val relayDetailsQueryService: RelayDetailsQueryService,
 ) {
     @Operation(summary = "Returns all relay details for a given relay.")
     @GetMapping("relay/{id}")
-    fun getRelay(@PathVariable id: Long): RelayDetails {
-        val details = relayDetailsRepositoryImpl.findById(id)
-        return if (details.isPresent) details.get() else throw RelayNotFoundException()
-    }
+    fun getRelay(@PathVariable id: Long) = relayDetailsQueryService.getRelay(id)
 
     @Operation(summary = "Returns all relay details for a given family.")
     @GetMapping("family/{id}")

--- a/backend/src/main/kotlin/org/tormap/adapter/dto/RelayDetailsDto.kt
+++ b/backend/src/main/kotlin/org/tormap/adapter/dto/RelayDetailsDto.kt
@@ -1,0 +1,40 @@
+@file:Suppress("unused")
+
+package org.tormap.adapter.dto
+
+import org.tormap.database.entity.RelayDetails
+import org.tormap.service.ReverseDnsLookupResult
+
+class RelayDetailsDto(
+    details: RelayDetails,
+    confirmedFamilyMembers: List<RelayIdentifiersDto>,
+    reverseDnsLookupResult: ReverseDnsLookupResult,
+) {
+    val id = details.id!!
+    val month = details.month
+    val day = details.day
+    val address = details.address
+    val autonomousSystemName = details.autonomousSystemName
+    val autonomousSystemNumber = details.autonomousSystemNumber
+    val allowSingleHopExits = details.allowSingleHopExits
+    val nickname = details.nickname
+    val bandwidthRate = details.bandwidthRate
+    val bandwidthBurst = details.bandwidthBurst
+    val bandwidthObserved = details.bandwidthObserved
+    val platform = details.platform
+    val protocols = details.protocols
+    val fingerprint = details.fingerprint
+    val isHibernating = details.isHibernating
+    val uptime = details.uptime
+    val contact = details.contact
+    val familyEntries = details.familyEntries
+    val familyId = details.familyId
+    val cachesExtraInfo = details.cachesExtraInfo
+    val isHiddenServiceDir = details.isHiddenServiceDir
+    val linkProtocolVersions = details.linkProtocolVersions
+    val circuitProtocolVersions = details.circuitProtocolVersions
+    val tunnelledDirServer = details.tunnelledDirServer
+    val confirmedFamilyMembers = confirmedFamilyMembers
+    val verifiedHostNames = reverseDnsLookupResult.verifiedHostNames
+    val unverifiedHostNames = reverseDnsLookupResult.unverifiedHostNames
+}

--- a/backend/src/main/kotlin/org/tormap/config/CacheConfig.kt
+++ b/backend/src/main/kotlin/org/tormap/config/CacheConfig.kt
@@ -6,6 +6,7 @@ import org.ehcache.jsr107.Eh107Configuration
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.tormap.service.ReverseDnsLookupResult
 import javax.cache.CacheManager
 import javax.cache.Caching
 
@@ -16,6 +17,7 @@ class CacheConfig {
         const val RELAY_LOCATION_DISTINCT_DAYS = "RELAY_LOCATION_DISTINCT_DAYS"
         const val RELAY_LOCATION_DISTINCT_DAYS_KEY = "RELAY_LOCATION_DISTINCT_DAYS_KEY"
         const val RELAY_LOCATIONS_PER_DAY = "RELAY_LOCATIONS_OF_DAY"
+        const val REVERSE_DNS_LOOKUPS = "REVERSE_DNS_LOOKUPS"
     }
 
     @Bean
@@ -39,6 +41,17 @@ class CacheConfig {
                 CacheConfigurationBuilder.newCacheConfigurationBuilder(
                     String::class.java, List::class.java,
                     ResourcePoolsBuilder.heap(40) // 1 entry ~= 2.5 MB of memory -> 40 entries ~= 100 MB of memory
+                )
+            )
+        )
+
+        cacheManager.createCache(
+            REVERSE_DNS_LOOKUPS,
+            Eh107Configuration.fromEhcacheCacheConfiguration(
+                CacheConfigurationBuilder.newCacheConfigurationBuilder(
+                    String::class.java,
+                    ReverseDnsLookupResult::class.java,
+                    ResourcePoolsBuilder.heap(10000)
                 )
             )
         )

--- a/backend/src/main/kotlin/org/tormap/service/RelayDetailsQueryService.kt
+++ b/backend/src/main/kotlin/org/tormap/service/RelayDetailsQueryService.kt
@@ -1,0 +1,50 @@
+package org.tormap.service
+
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
+import org.tormap.adapter.controller.exception.RelayNotFoundException
+import org.tormap.adapter.dto.RelayDetailsDto
+import org.tormap.adapter.dto.RelayIdentifiersDto
+import org.tormap.database.entity.RelayDetails
+import org.tormap.database.repository.RelayDetailsRepository
+
+interface RelayDetailsLookup {
+    fun findById(id: Long): RelayDetails?
+    fun findAllByFamilyId(familyId: Long): List<RelayDetails>
+}
+
+@Component
+class RelayDetailsRepositoryLookup(
+    private val relayDetailsRepository: RelayDetailsRepository,
+) : RelayDetailsLookup {
+    override fun findById(id: Long): RelayDetails? = relayDetailsRepository.findById(id).orElse(null)
+
+    override fun findAllByFamilyId(familyId: Long): List<RelayDetails> = relayDetailsRepository.findAllByFamilyId(familyId)
+}
+
+@Service
+class RelayDetailsQueryService(
+    private val relayDetailsLookup: RelayDetailsLookup,
+    private val reverseDnsLookupService: ReverseDnsLookupService,
+) {
+    fun getRelay(id: Long): RelayDetailsDto {
+        val details = relayDetailsLookup.findById(id) ?: throw RelayNotFoundException()
+        return RelayDetailsDto(
+            details = details,
+            confirmedFamilyMembers = details.confirmedFamilyMembers(),
+            reverseDnsLookupResult = reverseDnsLookupService.lookupHostNames(details.address),
+        )
+    }
+
+    private fun RelayDetails.confirmedFamilyMembers(): List<RelayIdentifiersDto> {
+        val currentRelayId = id ?: return emptyList()
+        val currentFamilyId = familyId ?: return emptyList()
+        return relayDetailsLookup.findAllByFamilyId(currentFamilyId)
+            .asSequence()
+            .filter { it.id != currentRelayId }
+            .distinctBy { it.id }
+            .sortedBy { it.nickname.lowercase() }
+            .map { RelayIdentifiersDto(it.id!!, it.fingerprint, it.nickname) }
+            .toList()
+    }
+}

--- a/backend/src/main/kotlin/org/tormap/service/ReverseDnsLookupService.kt
+++ b/backend/src/main/kotlin/org/tormap/service/ReverseDnsLookupService.kt
@@ -1,0 +1,80 @@
+package org.tormap.service
+
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
+import org.tormap.config.CacheConfig
+import java.net.InetAddress
+import java.net.UnknownHostException
+import java.util.Hashtable
+import javax.naming.Context
+import javax.naming.NamingException
+import javax.naming.directory.Attributes
+import javax.naming.directory.InitialDirContext
+
+data class ReverseDnsLookupResult(
+    val verifiedHostNames: List<String> = emptyList(),
+    val unverifiedHostNames: List<String> = emptyList(),
+)
+
+interface ReverseDnsResolver {
+    fun lookupPtrRecords(ipAddress: String): List<String>
+    fun lookupAddresses(hostName: String): List<String>
+}
+
+@Component
+class JndiReverseDnsResolver : ReverseDnsResolver {
+    override fun lookupPtrRecords(ipAddress: String): List<String> {
+        val environment = Hashtable<String, String>()
+        environment[Context.INITIAL_CONTEXT_FACTORY] = "com.sun.jndi.dns.DnsContextFactory"
+        var context: InitialDirContext? = null
+        return try {
+            context = InitialDirContext(environment)
+            val attributes = context.getAttributes(ipAddress.toReverseLookupDomain(), arrayOf("PTR"))
+            attributes.getAttributeValues("PTR").map { it.trimEnd('.') }
+        } catch (_: NamingException) {
+            emptyList()
+        } finally {
+            context?.close()
+        }
+    }
+
+    override fun lookupAddresses(hostName: String): List<String> = try {
+        InetAddress.getAllByName(hostName).map { it.hostAddress }
+    } catch (_: UnknownHostException) {
+        emptyList()
+    }
+}
+
+@Service
+class ReverseDnsLookupService(
+    private val reverseDnsResolver: ReverseDnsResolver,
+) {
+    @Cacheable(CacheConfig.REVERSE_DNS_LOOKUPS, key = "#ipAddress")
+    fun lookupHostNames(ipAddress: String): ReverseDnsLookupResult {
+        val hostNames = reverseDnsResolver.lookupPtrRecords(ipAddress)
+            .map { it.trim().trimEnd('.') }
+            .filter { it.isNotBlank() }
+            .distinct()
+
+        if (hostNames.isEmpty()) {
+            return ReverseDnsLookupResult()
+        }
+
+        val (verifiedHostNames, unverifiedHostNames) = hostNames.partition { hostName ->
+            reverseDnsResolver.lookupAddresses(hostName).any { it == ipAddress }
+        }
+
+        return ReverseDnsLookupResult(
+            verifiedHostNames = verifiedHostNames,
+            unverifiedHostNames = unverifiedHostNames,
+        )
+    }
+}
+
+private fun String.toReverseLookupDomain(): String = split('.').reversed().joinToString(".") + ".in-addr.arpa"
+
+private fun Attributes.getAttributeValues(attributeName: String): List<String> {
+    val attribute = get(attributeName) ?: return emptyList()
+    return (0 until attribute.size()).map { attribute.get(it).toString() }
+}

--- a/backend/src/test/kotlin/org/tormap/config/CacheConfigTest.kt
+++ b/backend/src/test/kotlin/org/tormap/config/CacheConfigTest.kt
@@ -13,14 +13,17 @@ class CacheConfigTest(
 ): StringSpec({
     val relayLocationDistinctDaysCache = cacheManager.getCache(CacheConfig.RELAY_LOCATION_DISTINCT_DAYS)
     val relayLocationsPerDayCache = cacheManager.getCache(CacheConfig.RELAY_LOCATIONS_PER_DAY)
+    val reverseDnsLookupsCache = cacheManager.getCache(CacheConfig.REVERSE_DNS_LOOKUPS)
 
     beforeEach {
         relayLocationDistinctDaysCache?.clear()
         relayLocationsPerDayCache?.clear()
+        reverseDnsLookupsCache?.clear()
     }
 
     "caches exists" {
         relayLocationDistinctDaysCache shouldNotBe null
         relayLocationsPerDayCache shouldNotBe null
+        reverseDnsLookupsCache shouldNotBe null
     }
 })

--- a/backend/src/test/kotlin/org/tormap/service/RelayDetailsQueryServiceTest.kt
+++ b/backend/src/test/kotlin/org/tormap/service/RelayDetailsQueryServiceTest.kt
@@ -1,0 +1,94 @@
+package org.tormap.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.tormap.adapter.controller.exception.RelayNotFoundException
+import org.tormap.database.entity.RelayDetails
+import org.tormap.mockRelayDetails
+
+class RelayDetailsQueryServiceTest : StringSpec({
+    "getRelay enriches relay details with confirmed family members and reverse DNS names" {
+        val relay = mockRelayDetails('A').apply {
+            id = 1L
+            familyId = 11L
+            address = "1.2.3.4"
+        }
+        val familyMember = mockRelayDetails('B').apply {
+            id = 2L
+            familyId = 11L
+        }
+
+        val relayDetailsQueryService = RelayDetailsQueryService(
+            relayDetailsLookup = FakeRelayDetailsLookup(
+                relaysById = mapOf(1L to relay),
+                relaysByFamilyId = mapOf(11L to listOf(relay, familyMember)),
+            ),
+            reverseDnsLookupService = ReverseDnsLookupService(
+                reverseDnsResolver = QueryServiceFakeReverseDnsResolver(
+                    ptrRecordsByIpAddress = mapOf(
+                        "1.2.3.4" to listOf("verified.example.", "unverified.example.")
+                    ),
+                    addressesByHostName = mapOf(
+                        "verified.example" to listOf("1.2.3.4"),
+                        "unverified.example" to listOf("5.6.7.8"),
+                    ),
+                )
+            ),
+        )
+
+        val response = relayDetailsQueryService.getRelay(1L)
+
+        response.id shouldBe 1L
+        response.confirmedFamilyMembers.map { it.id } shouldBe listOf(2L)
+        response.confirmedFamilyMembers.map { it.nickname } shouldBe listOf(familyMember.nickname)
+        response.verifiedHostNames shouldBe listOf("verified.example")
+        response.unverifiedHostNames shouldBe listOf("unverified.example")
+    }
+
+    "getRelay returns empty confirmed family members when relay has no family" {
+        val relay = mockRelayDetails('A').apply {
+            id = 1L
+            familyId = null
+            address = "1.2.3.4"
+        }
+
+        val relayDetailsQueryService = RelayDetailsQueryService(
+            relayDetailsLookup = FakeRelayDetailsLookup(relaysById = mapOf(1L to relay)),
+            reverseDnsLookupService = ReverseDnsLookupService(QueryServiceFakeReverseDnsResolver()),
+        )
+
+        val response = relayDetailsQueryService.getRelay(1L)
+
+        response.confirmedFamilyMembers shouldBe emptyList()
+    }
+
+    "getRelay throws when relay does not exist" {
+        val relayDetailsQueryService = RelayDetailsQueryService(
+            relayDetailsLookup = FakeRelayDetailsLookup(),
+            reverseDnsLookupService = ReverseDnsLookupService(QueryServiceFakeReverseDnsResolver()),
+        )
+
+        shouldThrow<RelayNotFoundException> {
+            relayDetailsQueryService.getRelay(99L)
+        }
+    }
+})
+
+private class FakeRelayDetailsLookup(
+    private val relaysById: Map<Long, RelayDetails> = emptyMap(),
+    private val relaysByFamilyId: Map<Long, List<RelayDetails>> = emptyMap(),
+) : RelayDetailsLookup {
+    override fun findById(id: Long): RelayDetails? = relaysById[id]
+
+    override fun findAllByFamilyId(familyId: Long): List<RelayDetails> = relaysByFamilyId[familyId] ?: emptyList()
+}
+
+private class QueryServiceFakeReverseDnsResolver(
+    private val ptrRecordsByIpAddress: Map<String, List<String>> = emptyMap(),
+    private val addressesByHostName: Map<String, List<String>> = emptyMap(),
+) : ReverseDnsResolver {
+    override fun lookupPtrRecords(ipAddress: String): List<String> = ptrRecordsByIpAddress[ipAddress] ?: emptyList()
+
+    override fun lookupAddresses(hostName: String): List<String> = addressesByHostName[hostName] ?: emptyList()
+}

--- a/backend/src/test/kotlin/org/tormap/service/ReverseDnsLookupServiceTest.kt
+++ b/backend/src/test/kotlin/org/tormap/service/ReverseDnsLookupServiceTest.kt
@@ -1,0 +1,52 @@
+package org.tormap.service
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ReverseDnsLookupServiceTest : StringSpec({
+    "lookupHostNames separates verified and unverified host names" {
+        val reverseDnsResolver = LookupServiceFakeReverseDnsResolver(
+            ptrRecordsByIpAddress = mapOf(
+                "1.2.3.4" to listOf(
+                    "verified.example.",
+                    "verified.example.",
+                    "unverified.example.",
+                )
+            ),
+            addressesByHostName = mapOf(
+                "verified.example" to listOf("1.2.3.4"),
+                "unverified.example" to listOf("5.6.7.8"),
+            ),
+        )
+        val reverseDnsLookupService = ReverseDnsLookupService(reverseDnsResolver)
+
+        val result = reverseDnsLookupService.lookupHostNames("1.2.3.4")
+
+        result.verifiedHostNames shouldBe listOf("verified.example")
+        result.unverifiedHostNames shouldBe listOf("unverified.example")
+    }
+
+    "lookupHostNames returns empty lists when no PTR records exist" {
+        val reverseDnsResolver = LookupServiceFakeReverseDnsResolver()
+        val reverseDnsLookupService = ReverseDnsLookupService(reverseDnsResolver)
+
+        val result = reverseDnsLookupService.lookupHostNames("1.2.3.4")
+
+        result shouldBe ReverseDnsLookupResult()
+        reverseDnsResolver.lookupAddressesCallCount shouldBe 0
+    }
+})
+
+private class LookupServiceFakeReverseDnsResolver(
+    private val ptrRecordsByIpAddress: Map<String, List<String>> = emptyMap(),
+    private val addressesByHostName: Map<String, List<String>> = emptyMap(),
+) : ReverseDnsResolver {
+    var lookupAddressesCallCount = 0
+
+    override fun lookupPtrRecords(ipAddress: String): List<String> = ptrRecordsByIpAddress[ipAddress] ?: emptyList()
+
+    override fun lookupAddresses(hostName: String): List<String> {
+        lookupAddressesCallCount++
+        return addressesByHostName[hostName] ?: emptyList()
+    }
+}

--- a/frontend/src/components/buttons/SelectFamilyButton.tsx
+++ b/frontend/src/components/buttons/SelectFamilyButton.tsx
@@ -1,4 +1,4 @@
-import {IconButton} from "@mui/material";
+import {Button, IconButton} from "@mui/material";
 import React, {FunctionComponent} from "react";
 
 import {useSettings} from "../../context/settings-context";
@@ -8,27 +8,47 @@ import {calculateFamilyColor} from "../../util/layer-construction";
 interface Props {
     familyId: number,
     furtherAction?: () => void,
+    label?: string,
 }
 
-export const SelectFamilyButton: FunctionComponent<Props> = ({familyId, furtherAction}) => {
+export const SelectFamilyButton: FunctionComponent<Props> = ({familyId, furtherAction, label}) => {
     // App context
     const {settings, setSettings} = useSettings()
+    const familyColor = calculateFamilyColor(familyId)
 
-    return (
-        <IconButton
+    const handleSelectFamily = () => {
+        setSettings({
+            ...settings,
+            selectedFamily: familyId,
+            sortFamily: true
+        })
+        if (furtherAction) {
+            furtherAction()
+        }
+    }
+
+    return label ? (
+        <Button
             aria-label="select family"
-            onClick={() => {
-                setSettings({
-                    ...settings,
-                    selectedFamily: familyId,
-                    sortFamily: true
-                })
-                if (furtherAction) {
-                    furtherAction()
+            onClick={handleSelectFamily}
+            startIcon={RelayFamilyIcon}
+            variant="outlined"
+            sx={{
+                color: familyColor,
+                borderColor: familyColor,
+                "&:hover": {
+                    borderColor: familyColor,
                 }
             }}
+        >
+            {label}
+        </Button>
+    ) : (
+        <IconButton
+            aria-label="select family"
+            onClick={handleSelectFamily}
             sx={{
-                color: calculateFamilyColor(familyId)
+                color: familyColor
             }}
         >
             {RelayFamilyIcon}

--- a/frontend/src/components/dialogs/relay/RelayDetailsDialogLarge.tsx
+++ b/frontend/src/components/dialogs/relay/RelayDetailsDialogLarge.tsx
@@ -54,7 +54,11 @@ export const RelayDetailsDialogLarge: React.FunctionComponent<DetailsDialogProps
                 </Grid>}
                 <Grid item xs={12} sm={canShowRelayList ? 8 : 12}
                       sx={{maxHeight: "70vh", overflow: 'auto'}}>
-                    {relayDetailsMatch && <RelayDetailsTable relayDetailsMatch={relayDetailsMatch}/>}
+                    {relayDetailsMatch &&
+                        <RelayDetailsTable
+                            relayDetailsMatch={relayDetailsMatch}
+                            closeDialog={closeDialog}
+                        />}
                 </Grid>
             </Grid>
         </Dialog>

--- a/frontend/src/components/dialogs/relay/RelayDetailsDialogSmall.tsx
+++ b/frontend/src/components/dialogs/relay/RelayDetailsDialogSmall.tsx
@@ -70,7 +70,11 @@ export const RelayDetailsDialogSmall: FunctionComponent<DetailsDialogProps> = ({
                 </AppBar>
                 <DialogContent>
                     {showRelayDetails ?
-                        relayDetailsMatch ? <RelayDetailsTable relayDetailsMatch={relayDetailsMatch}/> :
+                        relayDetailsMatch ?
+                            <RelayDetailsTable
+                                relayDetailsMatch={relayDetailsMatch}
+                                closeDialog={closeDialog}
+                            /> :
                             <LoadingAnimation/> :
                         <RelayList
                             relayMatches={filteredRelayMatches}

--- a/frontend/src/components/dialogs/relay/RelayDetailsTable.tsx
+++ b/frontend/src/components/dialogs/relay/RelayDetailsTable.tsx
@@ -1,15 +1,17 @@
-import {Table, TableBody, TableCell, TableRow, Typography} from "@mui/material";
+import {Box, Table, TableBody, TableCell, TableRow, Typography} from "@mui/material";
 import React, {FunctionComponent} from "react";
 
 import {RelayDetailsMatch, RelayFlag, RelayFlagLabel} from "../../../types/relay";
 import {ExternalLink} from "../../link/ExternalLink";
+import {SelectFamilyButton} from "../../buttons/SelectFamilyButton";
 
 interface Props {
     relayDetailsMatch: RelayDetailsMatch
+    closeDialog: () => void
 }
 
-export const RelayDetailsTable: FunctionComponent<Props> = ({relayDetailsMatch}) => {
-    const tableRows: RelayDetailsTableRow[] = [
+export const RelayDetailsTable: FunctionComponent<Props> = ({relayDetailsMatch, closeDialog}) => {
+    const tableRows = [
         {
             name: "Fingerprint",
             value:
@@ -32,10 +34,7 @@ export const RelayDetailsTable: FunctionComponent<Props> = ({relayDetailsMatch})
         },
         {
             name: "Autonomous System",
-            value: <ExternalLink
-                href={`https://metrics.torproject.org/rs.html#search/as:${relayDetailsMatch.autonomousSystemNumber}`}
-                label={`${relayDetailsMatch.autonomousSystemName} (${relayDetailsMatch.autonomousSystemNumber})`}
-            />
+            value: renderAutonomousSystem(relayDetailsMatch.autonomousSystemName, relayDetailsMatch.autonomousSystemNumber)
         },
         {name: "Platform", value: relayDetailsMatch.platform},
         {name: "Uptime", value: formatSecondsToHours(relayDetailsMatch.uptime)},
@@ -52,20 +51,33 @@ export const RelayDetailsTable: FunctionComponent<Props> = ({relayDetailsMatch})
         {name: "Link protocol versions", value: relayDetailsMatch.linkProtocolVersions},
         {name: "Circuit protocol versions", value: relayDetailsMatch.circuitProtocolVersions},
         {name: "Self reported family members", value: relayDetailsMatch.familyEntries},
+        {
+            name: "Confirmed family members",
+            value: renderConfirmedFamilyMembers(relayDetailsMatch.confirmedFamilyMembers)
+        },
+        relayDetailsMatch.familyId ? {
+            name: "Show family on map",
+            value: <SelectFamilyButton
+                familyId={relayDetailsMatch.familyId}
+                furtherAction={closeDialog}
+                label="Show confirmed family"
+            />
+        } : undefined,
+        {name: "Verified host names", value: renderHostNames(relayDetailsMatch.verifiedHostNames)},
+        {name: "Unverified host names", value: renderHostNames(relayDetailsMatch.unverifiedHostNames)},
         {name: "Infos published by relay on", value: relayDetailsMatch.day},
-    ]
+    ].filter(isTableRow) as RelayDetailsTableRow[]
 
     return (
         <Table size={"small"}>
             <TableBody>
                 {tableRows.map((row) =>
-                    row.value &&
                     <TableRow key={row.name}>
                         <TableCell scope="row" sx={{minWidth: "150px",}}>
                             <Typography>{row.name}</Typography>
                         </TableCell>
                         <TableCell scope="row">
-                            <Typography>{row.value}</Typography>
+                            {renderTableRowValue(row.value)}
                         </TableCell>
                     </TableRow>
                 )}
@@ -78,6 +90,13 @@ interface RelayDetailsTableRow {
     name: string
     value: string | number | React.ReactNode | undefined
 }
+
+const isTableRow = (row: RelayDetailsTableRow | undefined): row is RelayDetailsTableRow =>
+    row !== undefined && row.value !== undefined && row.value !== null && row.value !== ""
+
+const renderTableRowValue = (value: RelayDetailsTableRow["value"]) => typeof value === "string" || typeof value === "number" ?
+    <Typography>{value}</Typography> :
+    value
 
 const formatBytesToMBPerSecond = (bandwidthInBytes?: number) => bandwidthInBytes ?
     (bandwidthInBytes / 1000000).toFixed(2) + " MB/s"
@@ -95,3 +114,35 @@ const constructFlagString = (flags: RelayFlag[] | null | undefined) => {
     }
     return "no flags assigned"
 }
+
+const renderAutonomousSystem = (autonomousSystemName?: string, autonomousSystemNumber?: number | null) =>
+    autonomousSystemName && autonomousSystemNumber !== null && autonomousSystemNumber !== undefined ?
+        <ExternalLink
+            href={`https://metrics.torproject.org/rs.html#search/as:${autonomousSystemNumber}`}
+            label={`${autonomousSystemName} (${autonomousSystemNumber})`}
+        /> :
+        undefined
+
+const renderConfirmedFamilyMembers = (confirmedFamilyMembers?: {
+    id: number
+    fingerprint: string
+    nickname: string
+}[]) => confirmedFamilyMembers && confirmedFamilyMembers.length > 0 ?
+    <Box sx={{display: "flex", flexDirection: "column", gap: 0.5}}>
+        {confirmedFamilyMembers.map((familyMember) =>
+            <ExternalLink
+                key={familyMember.id}
+                href={`https://metrics.torproject.org/rs.html#details/${familyMember.fingerprint}`}
+                label={`${familyMember.nickname} (${familyMember.fingerprint})`}
+            />
+        )}
+    </Box> :
+    undefined
+
+const renderHostNames = (hostNames?: string[]) => hostNames && hostNames.length > 0 ?
+    <Box sx={{display: "flex", flexDirection: "column", gap: 0.5}}>
+        {hostNames.map((hostName) =>
+            <Typography key={hostName}>{hostName}</Typography>
+        )}
+    </Box> :
+    undefined

--- a/frontend/src/dto/relay.ts
+++ b/frontend/src/dto/relay.ts
@@ -16,7 +16,7 @@ export interface RelayDetailsDto {
     day: string
     address: string
     autonomousSystemName: string
-    autonomousSystemNumber: string
+    autonomousSystemNumber?: number | null
     allowSingleHopExits: boolean
     nickname: string
     bandwidthRate: number
@@ -29,11 +29,15 @@ export interface RelayDetailsDto {
     uptime: number
     contact: string
     familyEntries: string
+    familyId?: number | null
     cachesExtraInfo: boolean
     isHiddenServiceDir: boolean
     linkProtocolVersions: string
     circuitProtocolVersions: string
     tunnelledDirServer: boolean
+    confirmedFamilyMembers: RelayIdentifierDto[]
+    verifiedHostNames: string[]
+    unverifiedHostNames: string[]
 }
 
 export interface RelayIdentifierDto {


### PR DESCRIPTION
Fixes #26.

## Summary
- return enriched relay details with confirmed family members and verified/unverified reverse-DNS host names
- add backend lookup and caching for reverse-DNS results
- render the new relay dialog sections and add an explicit action to show the confirmed family on the map

## Verification
- ./gradlew.bat test --tests org.tormap.service.ReverseDnsLookupServiceTest --tests org.tormap.service.RelayDetailsQueryServiceTest
- corepack yarn install --immutable
- corepack yarn build
- corepack yarn lint

## Notes
- The full backend Spring test suite still depends on Docker/Testcontainers; it was not runnable in this environment without Docker.