### PR TITLE
ci: prevent tag-name bypass by requiring branch refs for frontend deploys

### DIFF
--- a/.github/workflows/frontend-push.yml
+++ b/.github/workflows/frontend-push.yml
@@ -23,7 +23,7 @@ jobs:
           yarn build
 
       - name: Deploy to dev.tormap.org
-        if: github.ref_name == 'dev'
+        if: github.ref_type == 'branch' && github.ref_name == 'dev'
         uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
@@ -35,7 +35,7 @@ jobs:
           FIREBASE_CLI_PREVIEWS: hostingchannels
 
       - name: Deploy to live tormap.org
-        if: github.ref_name == 'master'
+        if: github.ref_type == 'branch' && github.ref_name == 'master'
         uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
### Motivation
- Prevent push events on tags whose short names match protected branches from unintentionally triggering frontend deployments by ensuring deploy guards distinguish branches from tags instead of relying solely on `github.ref_name`.

### Description
- Update ` .github/workflows/frontend-push.yml` to require `github.ref_type == 'branch'` in the deploy step `if:` conditions, changing the dev and prod checks to `github.ref_type == 'branch' && github.ref_name == 'dev'` and `github.ref_type == 'branch' && github.ref_name == 'master'` respectively.

### Testing
- Ran `git diff -- .github/workflows/frontend-push.yml`, `git diff --check`, and `git commit` which all succeeded, and attempted YAML parsing via `yaml.safe_load` which failed due to `PyYAML` not being installed in the environment so no automated YAML linter was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0ef7b141c832c9e9ecde83bb9b075)