### PR TITLE
Split frontend build and deploy into separate GitHub Actions jobs and add artifact upload/download

### DIFF
--- a/.github/workflows/frontend-push.yml
+++ b/.github/workflows/frontend-push.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  frontend_build_deploy:
+  frontend_build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -21,6 +21,25 @@ jobs:
           cd frontend
           yarn install --immutable
           yarn build
+
+      - name: Upload frontend build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/build
+          if-no-files-found: error
+
+  frontend_deploy:
+    runs-on: ubuntu-latest
+    needs: frontend_build
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download frontend build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/build
 
       - name: Deploy to dev.tormap.org
         if: github.ref_name == 'dev'


### PR DESCRIPTION
### Motivation
- Decouple build and deploy steps to avoid redundant builds and allow the build output to be passed between jobs as an artifact.

### Description
- Rename `frontend_build_deploy` to `frontend_build` and perform the build with `yarn install --immutable` and `yarn build` inside the `frontend` directory.
- Add an `Upload frontend build artifact` step using `actions/upload-artifact@v4` to publish `frontend/build` as the `frontend-build` artifact.
- Add a new `frontend_deploy` job that `needs: frontend_build`, checks out the repo, and `Download frontend build artifact` using `actions/download-artifact@v4` into `frontend/build`.
- Preserve the existing conditional Firebase hosting deploy steps for `dev` and `master` branches using the same `entryPoint` and service account secrets.

### Testing
- No automated GitHub Actions workflow runs were executed as part of this change in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f12d0f5214832c98327226708c820d)