### PR TITLE
Split backend Docker workflow into separate build and push jobs and add tag verification

### DIFF
--- a/.github/workflows/backend-docker.yml
+++ b/.github/workflows/backend-docker.yml
@@ -6,16 +6,17 @@ on:
       - 'v*'
 
 jobs:
-  backend_docker:
+  build_backend_image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Login to DockerHub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Verify tagged commit is on master
+        run: |
+          git fetch origin master --depth=1
+          git merge-base --is-ancestor "$GITHUB_SHA" "origin/master"
 
       - name: Set up JDK 11
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -26,5 +27,40 @@ jobs:
       - uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
       - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3
 
-      - name: Build and push docker image
-        run: cd backend && ./gradlew jib
+      - name: Build docker image
+        run: cd backend && ./gradlew jibDockerBuild
+
+      - name: Save docker image artifact
+        run: docker save tormap/backend:latest -o /tmp/tormap-backend-image.tar
+
+      - name: Upload docker image artifact
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+        with:
+          name: tormap-backend-image
+          path: /tmp/tormap-backend-image.tar
+          retention-days: 1
+
+  push_backend_image:
+    runs-on: ubuntu-latest
+    needs: build_backend_image
+    steps:
+      - name: Download docker image artifact
+        uses: actions/download-artifact@b14f7f6df3e8e0c3901171b3180e90b4fedd5f10 # v4
+        with:
+          name: tormap-backend-image
+          path: /tmp
+
+      - name: Load docker image artifact
+        run: docker load -i /tmp/tormap-backend-image.tar
+
+      - name: Tag docker image
+        run: docker tag tormap/backend:latest tormap/backend:${GITHUB_REF_NAME}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push docker image
+        run: docker push tormap/backend:${GITHUB_REF_NAME}


### PR DESCRIPTION
### Motivation

- Ensure Docker image is built from a tagged commit that exists on `master` and avoid pushing directly from the build runner where DockerHub credentials are not needed. 
- Separate image build and push to allow artifact transfer between jobs and reduce credential exposure during the build step.

### Description

- Renamed the job from `backend_docker` to `build_backend_image` and set `fetch-depth: 0` on the checkout. 
- Added a `Verify tagged commit is on master` step that runs `git fetch origin master --depth=1` and `git merge-base --is-ancestor "$GITHUB_SHA" "origin/master"` to ensure the tag points to a commit on `master`. 
- Replaced `./gradlew jib` with `./gradlew jibDockerBuild` to produce a local Docker image, then `docker save` the image to `/tmp/tormap-backend-image.tar` and uploaded it with `actions/upload-artifact`. 
- Added a new `push_backend_image` job which downloads the artifact, `docker load`s it, tags it as `tormap/backend:${GITHUB_REF_NAME}`, logs into DockerHub with `docker/login-action`, and pushes the tagged image.

### Testing

- No automated tests were run as part of this PR; the workflow changes will be validated by GitHub Actions on the next tag push which will execute the `build_backend_image` and `push_backend_image` jobs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f135901aa4832c85e67fb28712c3cb)