### PR TITLE
Harden backend Docker workflow secret handling

### DIFF
--- a/.github/workflows/backend-docker.yml
+++ b/.github/workflows/backend-docker.yml
@@ -8,14 +8,12 @@ on:
 jobs:
   backend_docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Login to DockerHub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Set up JDK 11
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -27,4 +25,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3
 
       - name: Build and push docker image
+        env:
+          JIB_TO_AUTH_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          JIB_TO_AUTH_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: cd backend && ./gradlew jib


### PR DESCRIPTION
### Motivation
- The deploy workflow checked out repository code and authenticated to DockerHub before running the Gradle build, which let repository-controlled build logic access persisted GitHub credentials and Docker auth material. 
- The change aims to reduce credential exposure during CI by applying least-privilege and limiting when publishing secrets are available.

### Description
- Added minimal job-level permissions `contents: read` to restrict the job's token scope. 
- Configured `actions/checkout` with `persist-credentials: false` to avoid persisting the GitHub token in the local checkout. 
- Removed the separate `docker/login-action` usage and instead pass DockerHub credentials only to the final publish step via step-scoped environment variables `JIB_TO_AUTH_USERNAME` and `JIB_TO_AUTH_PASSWORD`.

### Testing
- No automated unit or integration tests were modified or required for this change. 
- Verified the updated workflow file contents and YAML structure locally using file inspection commands and a local diff, and the verification completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f14363ce9c832ca92dab74f96f7502)