### PR TITLE
Prevent overlapping autonomous system update jobs

### DIFF
--- a/backend/src/main/kotlin/org/tormap/service/RelayDetailsUpdateService.kt
+++ b/backend/src/main/kotlin/org/tormap/service/RelayDetailsUpdateService.kt
@@ -9,6 +9,7 @@ import org.tormap.util.commaSeparatedToList
 import org.tormap.util.getFamilyMember
 import org.tormap.util.logger
 import javax.sql.DataSource
+import java.util.concurrent.locks.ReentrantLock
 import javax.transaction.Transactional
 
 
@@ -24,6 +25,7 @@ class RelayDetailsUpdateService(
 ) {
     private val logger = logger()
     private val dbSequenceIncrementer = PostgresSequenceMaxValueIncrementer(dataSource, "hibernate_sequence")
+    private val autonomousSystemUpdateLock = ReentrantLock()
 
     /**
      * Updates [RelayDetails.autonomousSystemName] and [RelayDetails.autonomousSystemNumber] for all [RelayDetails] missing this info.
@@ -37,22 +39,30 @@ class RelayDetailsUpdateService(
     }
 
     fun lookupMissingAutonomousSystems(months: Set<String>) {
-        months.forEach { month ->
-            try {
-                logger.info("... Updating ASs for month: $month")
-                var changedRelaysCount = 0
-                val relaysWithoutAutonomousSystem =
-                    relayDetailsRepositoryImpl.findAllByMonthEqualsAndAutonomousSystemNumberNull(month)
-                relaysWithoutAutonomousSystem.forEach { relay ->
-                    if (relay.lookupAndSetAutonomousSystem()) {
-                        changedRelaysCount++
+        if (!autonomousSystemUpdateLock.tryLock()) {
+            logger.info("Skipping AS update for months ${months.joinToString(", ")} because another update is running")
+            return
+        }
+        try {
+            months.forEach { month ->
+                try {
+                    logger.info("... Updating ASs for month: $month")
+                    var changedRelaysCount = 0
+                    val relaysWithoutAutonomousSystem =
+                        relayDetailsRepositoryImpl.findAllByMonthEqualsAndAutonomousSystemNumberNull(month)
+                    relaysWithoutAutonomousSystem.forEach { relay ->
+                        if (relay.lookupAndSetAutonomousSystem()) {
+                            changedRelaysCount++
+                        }
                     }
+                    relayDetailsRepositoryImpl.saveAllAndFlush(relaysWithoutAutonomousSystem)
+                    logger.info("Determined the AS of $changedRelaysCount / ${relaysWithoutAutonomousSystem.size} relays for month $month")
+                } catch (exception: Exception) {
+                    logger.error("Could not update ASs for month $month! ${exception.message}")
                 }
-                relayDetailsRepositoryImpl.saveAllAndFlush(relaysWithoutAutonomousSystem)
-                logger.info("Determined the AS of $changedRelaysCount / ${relaysWithoutAutonomousSystem.size} relays for month $month")
-            } catch (exception: Exception) {
-                logger.error("Could not update ASs for month $month! ${exception.message}")
             }
+        } finally {
+            autonomousSystemUpdateLock.unlock()
         }
     }
 


### PR DESCRIPTION
### Motivation
- The asynchronous AS enrichment job can be invoked concurrently from the scheduler and descriptor processing paths, allowing overlapping runs that can repeatedly scan large tables and cause DB/thread-pool exhaustion.
- A minimal in-process synchronization is needed to avoid duplicate, overlapping month scans while preserving existing per-row lookup behavior.

### Description
- Add a `ReentrantLock` field `autonomousSystemUpdateLock` to `RelayDetailsUpdateService` and wrap `lookupMissingAutonomousSystems` with a non-blocking `tryLock()` guard to skip overlapping invocations with a log message. 
- Ensure the lock is released in a `finally` block so a failed run always clears the in-process marker, and otherwise preserve existing AS lookup and save behavior. 
- Change is localized to `backend/src/main/kotlin/org/tormap/service/RelayDetailsUpdateService.kt` and does not alter the per-row lookup logic or repository APIs.

### Testing
- Executed `cd backend && ./gradlew test --no-daemon` in the environment, which failed before test execution with a Gradle JVM error `25.0.1` so unit tests could not be run here. 
- Static project inspection and targeted local edits were applied and the file change was compiled locally in the editor, but automated tests could not be completed due to the environment failure described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f147940a28832c9f21ce3522c33f97)