### PR TITLE
Mitigate relay-details DNS lookup availability risk

### DIFF
--- a/backend/src/main/kotlin/org/tormap/service/ReverseDnsLookupService.kt
+++ b/backend/src/main/kotlin/org/tormap/service/ReverseDnsLookupService.kt
@@ -69,12 +69,16 @@ class DNSJavaReverseDnsResolver : ReverseDnsResolver {
 class ReverseDnsLookupService(
     private val reverseDnsResolver: ReverseDnsResolver,
 ) {
-    @Cacheable(CacheConfig.REVERSE_DNS_LOOKUPS, key = "#ipAddress")
+    companion object {
+        private const val MAX_PTR_HOSTNAMES_TO_VERIFY = 10
+    }
+    @Cacheable(CacheConfig.REVERSE_DNS_LOOKUPS, key = "#ipAddress", sync = true)
     fun lookupHostNames(ipAddress: String): ReverseDnsLookupResult {
         val hostNames = reverseDnsResolver.lookupPtrRecords(ipAddress)
             .map { it.trim().trimEnd('.') }
             .filter { it.isNotBlank() }
             .distinct()
+            .take(MAX_PTR_HOSTNAMES_TO_VERIFY)
 
         if (hostNames.isEmpty()) {
             return ReverseDnsLookupResult()

--- a/backend/src/test/kotlin/org/tormap/service/ReverseDnsLookupServiceIntegrationTest.kt
+++ b/backend/src/test/kotlin/org/tormap/service/ReverseDnsLookupServiceIntegrationTest.kt
@@ -1,0 +1,108 @@
+package org.tormap.service
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.cache.CacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.ActiveProfiles
+import org.tormap.config.CacheConfig
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(ReverseDnsLookupServiceIntegrationTestConfig::class)
+class ReverseDnsLookupServiceIntegrationTest(
+    private val reverseDnsLookupService: ReverseDnsLookupService,
+    private val cacheManager: CacheManager,
+    private val controllableResolver: ControllableReverseDnsResolver,
+) : StringSpec({
+    beforeEach {
+        cacheManager.getCache(CacheConfig.REVERSE_DNS_LOOKUPS)?.clear()
+        controllableResolver.reset()
+    }
+
+    "lookupHostNames result is cached so subsequent calls for the same IP skip the resolver" {
+        controllableResolver.configure(
+            ptrRecords = listOf("host1.example."),
+            addresses = mapOf("host1.example" to listOf("1.2.3.4")),
+        )
+
+        reverseDnsLookupService.lookupHostNames("1.2.3.4")
+        reverseDnsLookupService.lookupHostNames("1.2.3.4")
+
+        controllableResolver.lookupPtrRecordsCallCount.get() shouldBe 1
+    }
+
+    "concurrent cache misses for the same IP trigger only one DNS lookup" {
+        val threadCount = 10
+        val readyLatch = CountDownLatch(threadCount)
+        val startLatch = CountDownLatch(1)
+        controllableResolver.configure(
+            ptrRecords = listOf("host1.example."),
+            addresses = mapOf("host1.example" to listOf("1.2.3.4")),
+            delayMs = 50,
+        )
+
+        val executor = Executors.newFixedThreadPool(threadCount)
+        try {
+            repeat(threadCount) {
+                executor.submit {
+                    readyLatch.countDown()
+                    startLatch.await()
+                    reverseDnsLookupService.lookupHostNames("1.2.3.4")
+                }
+            }
+            readyLatch.await()
+            startLatch.countDown()
+            executor.shutdown()
+            executor.awaitTermination(10, TimeUnit.SECONDS)
+        } finally {
+            executor.shutdownNow()
+        }
+
+        controllableResolver.lookupPtrRecordsCallCount.get() shouldBe 1
+    }
+})
+
+class ControllableReverseDnsResolver : ReverseDnsResolver {
+    private var ptrRecords: List<String> = emptyList()
+    private var addresses: Map<String, List<String>> = emptyMap()
+    private var delayMs: Long = 0
+
+    val lookupPtrRecordsCallCount = AtomicInteger(0)
+
+    fun configure(ptrRecords: List<String>, addresses: Map<String, List<String>>, delayMs: Long = 0) {
+        this.ptrRecords = ptrRecords
+        this.addresses = addresses
+        this.delayMs = delayMs
+    }
+
+    fun reset() {
+        ptrRecords = emptyList()
+        addresses = emptyMap()
+        delayMs = 0
+        lookupPtrRecordsCallCount.set(0)
+    }
+
+    override fun lookupPtrRecords(ipAddress: String): List<String> {
+        lookupPtrRecordsCallCount.incrementAndGet()
+        if (delayMs > 0) Thread.sleep(delayMs)
+        return ptrRecords
+    }
+
+    override fun lookupAddresses(hostName: String): List<String> = addresses[hostName] ?: emptyList()
+}
+
+@TestConfiguration
+class ReverseDnsLookupServiceIntegrationTestConfig {
+    @Bean
+    @Primary
+    fun controllableReverseDnsResolver(): ControllableReverseDnsResolver = ControllableReverseDnsResolver()
+}

--- a/backend/src/test/kotlin/org/tormap/service/ReverseDnsLookupServiceTest.kt
+++ b/backend/src/test/kotlin/org/tormap/service/ReverseDnsLookupServiceTest.kt
@@ -35,6 +35,22 @@ class ReverseDnsLookupServiceTest : StringSpec({
         result shouldBe ReverseDnsLookupResult()
         reverseDnsResolver.lookupAddressesCallCount shouldBe 0
     }
+
+
+    "lookupHostNames limits number of host names verified" {
+        val ptrRecords = (1..20).map { "host$it.example." }
+        val reverseDnsResolver = LookupServiceFakeReverseDnsResolver(
+            ptrRecordsByIpAddress = mapOf("1.2.3.4" to ptrRecords),
+            addressesByHostName = ptrRecords.associate { it.trimEnd('.') to listOf("5.6.7.8") },
+        )
+        val reverseDnsLookupService = ReverseDnsLookupService(reverseDnsResolver)
+
+        val result = reverseDnsLookupService.lookupHostNames("1.2.3.4")
+
+        result.verifiedHostNames shouldBe emptyList()
+        result.unverifiedHostNames.size shouldBe 10
+        reverseDnsResolver.lookupAddressesCallCount shouldBe 10
+    }
 })
 
 private class LookupServiceFakeReverseDnsResolver(


### PR DESCRIPTION
### Motivation
- The public `relay/**` details endpoint performed unbounded, synchronous PTR and forward DNS lookups in the HTTP request path, allowing attacker-controlled PTR responses or slow DNS to tie up request threads and cause availability loss. 
- The cache previously only stored completed results and did not prevent concurrent cache-miss stampedes for the same IP, so multiple clients could all trigger heavy DNS work simultaneously.

### Description
- Bound verification work by adding `MAX_PTR_HOSTNAMES_TO_VERIFY = 10` and applying `.take(MAX_PTR_HOSTNAMES_TO_VERIFY)` to the distinct PTR hostnames list in `ReverseDnsLookupService.lookupHostNames` to cap forward-lookup calls per request. (`backend/src/main/kotlin/org/tormap/service/ReverseDnsLookupService.kt`)
- Enabled synchronized cache loading by adding `sync = true` to the `@Cacheable` annotation for reverse DNS lookups to reduce concurrent cache-miss stampedes for the same IP. (`backend/src/main/kotlin/org/tormap/service/ReverseDnsLookupService.kt`)
- Added a unit test `"lookupHostNames limits number of host names verified"` to `ReverseDnsLookupServiceTest` that verifies only 10 forward lookups are performed when PTR returns 20 names. (`backend/src/test/kotlin/org/tormap/service/ReverseDnsLookupServiceTest.kt`)

### Testing
- Added an automated unit test case in `org.tormap.service.ReverseDnsLookupServiceTest` that asserts the hostname verification limit and expected forward-lookup call count. 
- Attempted to run the tests with `./gradlew test --tests org.tormap.service.ReverseDnsLookupServiceTest --no-daemon`, but the run failed in this environment due to a JVM/Gradle compatibility issue reported as `25.0.1`, not due to the test logic itself, so tests could not be executed here. 
- No other automated test runs were completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f4bd6f977c832ca58a09880a343ec2)