### PR TITLE
ci: isolate PR concurrency groups

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -11,7 +11,7 @@ on:
       - '.github/workflows/backend*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend-pull-request.yml
+++ b/.github/workflows/frontend-pull-request.yml
@@ -7,7 +7,7 @@ on:
       - '.github/workflows/frontend*'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Motivation
- The PR workflows used `github.head_ref` in the concurrency group which is attacker-controlled and not globally unique, enabling a malicious PR from a fork that reuses a branch name to cancel another PR's in-progress runs when `cancel-in-progress: true` is set.
- The change scopes concurrency to the pull request identity to prevent cross-PR cancellation while preserving intended cancellation semantics for duplicated workflow runs in the same PR.

### Description
- Updated the concurrency `group` in `/.github/workflows/backend-test.yml` from `
`${{ github.workflow }}-${{ github.head_ref || github.ref }}`
` to `
`${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
` to key on the PR number for pull request runs.
- Applied the same change to `/.github/workflows/frontend-pull-request.yml` and left `cancel-in-progress: true` unchanged to preserve intra-PR cancellation behavior.

### Testing
- A small Python check asserted that neither `backend-test.yml` nor `frontend-pull-request.yml` contain the vulnerable `github.head_ref || github.ref` expression and do contain `github.event.pull_request.number || github.ref`, and the check passed.
- `git diff --check` was run and returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb7da5a80c832c9c7617ae531dfd44)