### PR TITLE
Persist final processed descriptor file to prevent repeated reprocessing

### DIFF
--- a/backend/src/main/kotlin/org/tormap/service/DescriptorCoordinationService.kt
+++ b/backend/src/main/kotlin/org/tormap/service/DescriptorCoordinationService.kt
@@ -77,6 +77,9 @@ class DescriptorCoordinationService(
             descriptorInfo.error?.let { errorCount++ }
             lastProcessedFile = descriptor.descriptorFile
         }
+        lastProcessedFile?.let {
+            handleFinishedFile(descriptorType, it, errorCount, processedMonthsFromFile)
+        }
         if (descriptorType.isRecent()) {
             computeRelayDetailsAndCaches(descriptorType, processedMonthsFromAllFiles)
         }

--- a/backend/src/test/kotlin/org/tormap/service/DescriptorCoordinationServiceTest.kt
+++ b/backend/src/test/kotlin/org/tormap/service/DescriptorCoordinationServiceTest.kt
@@ -1,0 +1,63 @@
+package org.tormap.service
+
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.tormap.config.value.DescriptorConfig
+import org.tormap.database.entity.DescriptorType
+import org.tormap.database.repository.RelayDetailsRepository
+import org.tormap.database.repository.RelayLocationRepository
+import org.torproject.descriptor.Descriptor
+import java.io.File
+
+class DescriptorCoordinationServiceTest : StringSpec({
+    "processLocalDescriptorFiles saves the final processed descriptor file" {
+        val descriptorConfig = mockk<DescriptorConfig>(relaxed = true)
+        val relayDetailsUpdateService = mockk<RelayDetailsUpdateService>(relaxed = true)
+        val descriptorFileService = mockk<DescriptorFileService>(relaxed = true)
+        val descriptorProcessingService = mockk<DescriptorProcessingService>()
+        val relayDetailsRepository = mockk<RelayDetailsRepository>(relaxed = true)
+        val relayLocationRepository = mockk<RelayLocationRepository>(relaxed = true)
+        val cacheService = mockk<CacheService>(relaxed = true)
+        val service = DescriptorCoordinationService(
+            descriptorConfig,
+            relayDetailsUpdateService,
+            descriptorFileService,
+            descriptorProcessingService,
+            relayDetailsRepository,
+            relayLocationRepository,
+            cacheService,
+        )
+        val firstFile = File("first-descriptors.tar.xz")
+        val finalFile = File("final-descriptors.tar.xz")
+        val descriptors = mutableListOf(
+            descriptorFrom(firstFile),
+            descriptorFrom(firstFile),
+            descriptorFrom(finalFile),
+        )
+
+        every {
+            descriptorFileService.getDescriptorDiskReader("/archive", DescriptorType.ARCHIVE_RELAY_CONSENSUS)
+        } returns descriptors
+        every { descriptorProcessingService.processDescriptor(any()) } returns ProcessedDescriptorInfo("2024-01")
+
+        DescriptorCoordinationService::class.java
+            .getDeclaredMethod("processLocalDescriptorFiles", String::class.java, DescriptorType::class.java)
+            .apply { isAccessible = true }
+            .invoke(service, "/archive", DescriptorType.ARCHIVE_RELAY_CONSENSUS)
+
+        verify(exactly = 1) {
+            descriptorFileService.saveProcessedFileReference(firstFile, DescriptorType.ARCHIVE_RELAY_CONSENSUS)
+        }
+        verify(exactly = 1) {
+            descriptorFileService.saveProcessedFileReference(finalFile, DescriptorType.ARCHIVE_RELAY_CONSENSUS)
+        }
+    }
+})
+
+private fun descriptorFrom(file: File): Descriptor {
+    val descriptor = mockk<Descriptor>()
+    every { descriptor.descriptorFile } returns file
+    return descriptor
+}


### PR DESCRIPTION
### Motivation
- The descriptor processing loop did not persist the final `lastProcessedFile` after iterating all descriptors, leaving the last archive unrecorded and eligible for reprocessing on subsequent scheduled runs. 
- Repeated reprocessing of a large final archive can cause sustained CPU, heap, and database pressure in the scheduled ingestion path.

### Description
- Ensure the final archive is flushed by invoking the existing finished-file path after the descriptor iteration completes: `lastProcessedFile?.let { handleFinishedFile(...) }` was added to `processLocalDescriptorFiles` in `DescriptorCoordinationService`. (`backend/src/main/kotlin/org/tormap/service/DescriptorCoordinationService.kt`)
- Add a regression test that simulates descriptors coming from two different files and verifies both the intermediate and final files are saved via `saveProcessedFileReference`. (`backend/src/test/kotlin/org/tormap/service/DescriptorCoordinationServiceTest.kt`)

### Testing
- Added unit test `org.tormap.service.DescriptorCoordinationServiceTest` that verifies the final processed descriptor file is saved; the test file is present in the tree. 
- Run attempts of the test with `./gradlew test --tests org.tormap.service.DescriptorCoordinationServiceTest` were blocked by the environment: the default Java runtime (`25.x`) is not supported by the Kotlin/Gradle tooling and switching to `JAVA_HOME=$(mise where java@17.0.2)` still failed to resolve the Kotlin Gradle plugin from the Gradle Central Plugin Repository in this environment. 
- Static checks such as `git diff --check` were executed with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb9a27e85c832c8ccdcf7cb629ef41)