### PR TITLE
Restrict shallow ETag filter routes

### DIFF
--- a/backend/src/main/kotlin/org/tormap/config/AppConfig.kt
+++ b/backend/src/main/kotlin/org/tormap/config/AppConfig.kt
@@ -1,6 +1,7 @@
 package org.tormap.config
 
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableAsync
@@ -30,12 +31,23 @@ class AppConfig : WebMvcConfigurer {
     }
 
     /**
-     * Include an unique ETag hash for each response to enable client side caching.
+     * Include a weak ETag hash only for small, bounded GET endpoints.
+     *
+     * Shallow ETags require Spring to buffer the full response body before it can be hashed.
+     * Keep this filter away from large public endpoints such as /relay/location/day/{day},
+     * where buffering an entire day's relay locations can amplify memory and CPU usage.
      */
     @Bean
-    fun shallowEtagHeaderFilter(): ShallowEtagHeaderFilter {
+    fun shallowEtagHeaderFilterRegistration(): FilterRegistrationBean<ShallowEtagHeaderFilter> {
         val filter = ShallowEtagHeaderFilter()
         filter.isWriteWeakETag = true
-        return filter
+
+        return FilterRegistrationBean(filter).apply {
+            addUrlPatterns(
+                "/relay/location/days",
+                "/relay/details/relay/*",
+                "/relay/details/family/*",
+            )
+        }
     }
 }

--- a/backend/src/test/kotlin/org/tormap/config/SecurityConfigTest.kt
+++ b/backend/src/test/kotlin/org/tormap/config/SecurityConfigTest.kt
@@ -1,8 +1,10 @@
 package org.tormap.config
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.ApplicationContext
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -10,6 +12,7 @@ import org.springframework.security.web.SecurityFilterChain
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.filter.ForwardedHeaderFilter
+import org.springframework.web.filter.ShallowEtagHeaderFilter
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -19,7 +22,8 @@ class SecurityConfigTest(
     private val userDetailsService: UserDetailsService,
     private val corsConfigurationSource: CorsConfigurationSource,
     private val forwardedHeaderFilter: ForwardedHeaderFilter,
-    private val securityFilterChain: SecurityFilterChain
+    private val securityFilterChain: SecurityFilterChain,
+    private val shallowEtagHeaderFilterRegistration: FilterRegistrationBean<ShallowEtagHeaderFilter>,
 ) : StringSpec({
 
     "security beans are loaded" {
@@ -29,6 +33,14 @@ class SecurityConfigTest(
         corsConfigurationSource shouldNotBe null
         forwardedHeaderFilter shouldNotBe null
         securityFilterChain shouldNotBe null
+    }
+
+    "shallow ETag filter is not registered for large relay location responses" {
+        shallowEtagHeaderFilterRegistration.urlPatterns shouldBe setOf(
+            "/relay/location/days",
+            "/relay/details/relay/*",
+            "/relay/details/family/*",
+        )
     }
 
 })

--- a/backend/src/test/kotlin/org/tormap/controller/HttpCachingConfigTest.kt
+++ b/backend/src/test/kotlin/org/tormap/controller/HttpCachingConfigTest.kt
@@ -2,6 +2,8 @@ package org.tormap.controller
 
 import io.kotest.core.spec.style.StringSpec
 import org.hamcrest.Matchers.containsString
+import org.tormap.database.repository.RelayDetailsRepository
+import org.tormap.mockRelayDetails
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -15,7 +17,37 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @ActiveProfiles("test")
 class HttpCachingConfigTest(
     private val mockMvc: MockMvc,
+    private val relayDetailsRepository: RelayDetailsRepository,
 ) : StringSpec({
+    val testRelay = relayDetailsRepository.save(
+        mockRelayDetails().apply {
+            familyId = 123L
+        }
+    )
+
+    "GET /relay/location/days includes ETag header" {
+        mockMvc.perform(get("/relay/location/days"))
+            .andExpect(status().isOk)
+            .andExpect(header().exists("ETag"))
+    }
+
+    "GET /relay/details/relay/{id} includes ETag header" {
+        mockMvc.perform(get("/relay/details/relay/${testRelay.id}"))
+            .andExpect(status().isOk)
+            .andExpect(header().exists("ETag"))
+    }
+
+    "GET /relay/details/family/{id} includes ETag header" {
+        mockMvc.perform(get("/relay/details/family/${testRelay.familyId}"))
+            .andExpect(status().isOk)
+            .andExpect(header().exists("ETag"))
+    }
+
+    "GET /relay/location/day/{day} does not include ETag header" {
+        mockMvc.perform(get("/relay/location/day/2022-02-04"))
+            .andExpect(status().isOk)
+            .andExpect(header().doesNotExist("ETag"))
+    }
 
     "GET /relay/location/days includes Cache-Control public max-age" {
         mockMvc.perform(get("/relay/location/days"))


### PR DESCRIPTION
### Motivation
- The global `ShallowEtagHeaderFilter` was being registered as an unrestricted bean which causes Spring to buffer full response bodies for ETag generation and can amplify memory/CPU usage for large public endpoints such as `/relay/location/day/{day}`. 
- The change aims to remove the global response-buffering behavior for unbounded endpoints while preserving ETag caching for small, bounded routes.

### Description
- Replace the globally auto-registered `ShallowEtagHeaderFilter` bean with a `FilterRegistrationBean<ShallowEtagHeaderFilter>` so the filter is only applied to explicitly listed small/bounded routes in `backend/src/main/kotlin/org/tormap/config/AppConfig.kt`.
- Limit the filter URL patterns to safe endpoints (`/relay/location/days`, `/relay/details/relay/*`, `/relay/details/family/*`) to avoid buffering large day-by-day relay responses.
- Update the Spring context test in `backend/src/test/kotlin/org/tormap/config/SecurityConfigTest.kt` to assert the `FilterRegistrationBean` is registered with the expected URL patterns.

### Testing
- Attempted to run the `SecurityConfigTest` with Gradle (`./gradlew --no-daemon test --tests org.tormap.config.SecurityConfigTest`), but the build failed in this environment because the Kotlin Gradle plugin could not be resolved from the plugin portal. (Test not executed.)
- Attempted the same test with `JAVA_HOME` set to Java 17 to work around a Java parsing issue, but the run still failed due to inability to resolve the `org.jetbrains.kotlin.jvm:1.9.25` plugin from the Gradle plugin repository in this environment. (Test not executed.)
- Ran repository checks (`git diff --check`) which reported no whitespace/diff errors on the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb967586cc832cb80fda9f467c7e16)