### PR TITLE
fix: synchronize CoalesceService slot lifecycle to prevent dropped reruns

### DIFF
--- a/backend/src/main/kotlin/org/tormap/service/CoalesceService.kt
+++ b/backend/src/main/kotlin/org/tormap/service/CoalesceService.kt
@@ -33,21 +33,25 @@ class CoalesceService(
 
     fun submitAsync(key: String, task: () -> Unit): CompletableFuture<Void> {
         val slot = slots.computeIfAbsent(key) { Slot() }
+        var firstFuture: CompletableFuture<Void>? = null
 
-        // If no run is in flight, start the loop and return a future for the first run.
-        if (slot.running.compareAndSet(false, true)) {
-            val firstFuture = CompletableFuture<Void>()
-            runLoopAsync(key, slot, task, firstFuture)
-            return firstFuture
-        }
-
-        // Already running: request one rerun (collapsed) and return the shared future for that rerun.
-        slot.rerunRequested.set(true)
         synchronized(slot.monitor) {
+            // If no run is in flight, start the loop and return a future for the first run.
+            if (!slot.running.get()) {
+                firstFuture = CompletableFuture<Void>()
+                slot.running.set(true)
+                return@synchronized
+            }
+
+            // Already running: request one rerun (collapsed) and return the shared future for that rerun.
+            slot.rerunRequested.set(true)
             val existing = slot.nextFuture
             if (existing != null) return existing
             return CompletableFuture<Void>().also { slot.nextFuture = it }
         }
+
+        runLoopAsync(key, slot, task, firstFuture!!)
+        return firstFuture!!
     }
 
     internal fun hasStateForKey(key: String): Boolean = slots.containsKey(key)
@@ -75,23 +79,21 @@ class CoalesceService(
                         continue
                     }
 
-                    // If no rerun requested, finish.
-                    if (!slot.rerunRequested.getAndSet(false)) {
-                        keepGoing = false
-                        continue
-                    }
+                    synchronized(slot.monitor) {
+                        // If no rerun requested, finish.
+                        if (!slot.rerunRequested.getAndSet(false)) {
+                            slot.running.set(false)
+                            slots.remove(key, slot)
+                            keepGoing = false
+                            continue
+                        }
 
-                    // Promote the shared next future for the rerun. If none exists (rare race), create one.
-                    currentFuture = synchronized(slot.monitor) {
+                        // Promote the shared next future for the rerun. If none exists (rare race), create one.
                         val next = slot.nextFuture ?: CompletableFuture<Void>()
                         slot.nextFuture = null
-                        next
+                        currentFuture = next
                     }
                 }
-
-                // Mark not running and remove slot. If a submit races here, it will start a new loop.
-                slot.running.set(false)
-                slots.remove(key, slot)
             },
             coalesceExecutor,
         )

--- a/backend/src/main/kotlin/org/tormap/service/CoalesceService.kt
+++ b/backend/src/main/kotlin/org/tormap/service/CoalesceService.kt
@@ -82,9 +82,16 @@ class CoalesceService(
                     } catch (ex: Exception) {
                         logger.error("Coalesced task failed for key={}", key, ex)
                         currentFuture?.completeExceptionally(ex)
+                        synchronized(slot.monitor) {
+                            val pendingNext = slot.nextFuture
+                            slot.nextFuture = null
+                            slot.rerunRequested.set(false)
+                            slot.running.set(false)
+                            slots.remove(key, slot)
+                            pendingNext?.completeExceptionally(ex)
+                        }
                         // Keep existing behavior: stop reruns for this cycle after a failed execution.
                         keepGoing = false
-                        continue
                     }
 
                     synchronized(slot.monitor) {
@@ -93,13 +100,12 @@ class CoalesceService(
                             slot.running.set(false)
                             slots.remove(key, slot)
                             keepGoing = false
-                            continue
+                        } else {
+                            // Promote the shared next future for the rerun. If none exists (rare race), create one.
+                            val next = slot.nextFuture ?: CompletableFuture<Void>()
+                            slot.nextFuture = null
+                            currentFuture = next
                         }
-
-                        // Promote the shared next future for the rerun. If none exists (rare race), create one.
-                        val next = slot.nextFuture ?: CompletableFuture<Void>()
-                        slot.nextFuture = null
-                        currentFuture = next
                     }
                 }
             },

--- a/backend/src/main/kotlin/org/tormap/service/CoalesceService.kt
+++ b/backend/src/main/kotlin/org/tormap/service/CoalesceService.kt
@@ -32,26 +32,34 @@ class CoalesceService(
     private val slots = ConcurrentHashMap<String, Slot>()
 
     fun submitAsync(key: String, task: () -> Unit): CompletableFuture<Void> {
-        val slot = slots.computeIfAbsent(key) { Slot() }
-        var firstFuture: CompletableFuture<Void>? = null
+        while (true) {
+            val slot = slots.computeIfAbsent(key) { Slot() }
+            var firstFuture: CompletableFuture<Void>? = null
 
-        synchronized(slot.monitor) {
-            // If no run is in flight, start the loop and return a future for the first run.
-            if (!slot.running.get()) {
-                firstFuture = CompletableFuture<Void>()
-                slot.running.set(true)
-                return@synchronized
+            val queuedFuture = synchronized(slot.monitor) {
+                if (slots[key] !== slot) return@synchronized null
+
+                // If no run is in flight, start the loop and return a future for the first run.
+                if (!slot.running.get()) {
+                    firstFuture = CompletableFuture<Void>()
+                    slot.running.set(true)
+                    return@synchronized null
+                }
+
+                // Already running: request one rerun (collapsed) and return the shared future for that rerun.
+                slot.rerunRequested.set(true)
+                val existing = slot.nextFuture
+                if (existing != null) return@synchronized existing
+                CompletableFuture<Void>().also { slot.nextFuture = it }
             }
 
-            // Already running: request one rerun (collapsed) and return the shared future for that rerun.
-            slot.rerunRequested.set(true)
-            val existing = slot.nextFuture
-            if (existing != null) return existing
-            return CompletableFuture<Void>().also { slot.nextFuture = it }
+            if (queuedFuture != null) return queuedFuture
+            val startFuture = firstFuture
+            if (startFuture != null) {
+                runLoopAsync(key, slot, task, startFuture)
+                return startFuture
+            }
         }
-
-        runLoopAsync(key, slot, task, firstFuture!!)
-        return firstFuture!!
     }
 
     internal fun hasStateForKey(key: String): Boolean = slots.containsKey(key)


### PR DESCRIPTION
### Motivation
- A recent refactor introduced a race in `CoalesceService` where submissions near task completion could create an orphan `nextFuture` (never completed) or allow duplicate concurrent executions for the same key. 
- This affects cache rebuilding and relay-detail recomputation jobs and can cause stale caches, hung `CompletableFuture.allOf` callers, duplicate DB/cache work, and extra lock contention.

### Description
- Serialize `submitAsync` state transitions (`running`, `rerunRequested`, `nextFuture`) by synchronizing on `slot.monitor` so the initial-run path sets `running` and prepares the first future while holding the lock. 
- Start the async run loop only after the monitor-held state is established to avoid submitters observing partially-shutdown state. 
- Move the worker-loop rerun check and shutdown (`running=false` + `slots.remove`) into the same `synchronized(slot.monitor)` block and promote/clear `nextFuture` there to prevent orphaned futures and stale-slot removal races. 
- Change is limited to `backend/src/main/kotlin/org/tormap/service/CoalesceService.kt` and preserves the intended coalescing semantics.

### Testing
- Attempted `./gradlew :backend:test --tests "org.tormap.service.CoalesceServiceTest"` at the repo root failed because `./gradlew` was not present in that path. (failed)
- Ran `cd backend && ./gradlew test --tests "org.tormap.service.CoalesceServiceTest"` which failed due to a Gradle/toolchain environment error (`25.0.2`), so unit tests could not be executed in this environment. (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0de336e3dc832c992989eeaf27e8d4)